### PR TITLE
Enabling RabbitMqMessageBus to be disposed by DefaultDependencyResolver

### DIFF
--- a/SignalR.RabbitMQ/RabbitMqMessageBus.cs
+++ b/SignalR.RabbitMQ/RabbitMqMessageBus.cs
@@ -29,14 +29,15 @@ namespace SignalR.RabbitMQ
             ConnectToRabbit(ampqConnectionString, applicationName);
         }
 
-        public new void Dispose()
-        {
-            if(_rabbitConnection != null)
-            {
-                _rabbitConnection.Dispose();
-            }
-            base.Dispose();
-        }
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && _rabbitConnection != null)
+			{
+				_rabbitConnection.Dispose();
+			}
+
+			base.Dispose(disposing);
+		}
 
         private void ConnectToRabbit(string ampqConnectionString, string applicationName)
         {


### PR DESCRIPTION
This replaces the `IDisposable` implementation that hides `Dispose()` (which won't be called when the caller is working with `IDisposable`) with one that overrides `Dispose(disposing)` (which will be called in the same scenario).
