### PR TITLE
Exchange and queue naming changes, using fanout

### DIFF
--- a/SignalR.RabbitMQ/DependencyResolverExtensions.cs
+++ b/SignalR.RabbitMQ/DependencyResolverExtensions.cs
@@ -7,11 +7,11 @@ namespace SignalR.RabbitMQ
 {
     public static class DependencyResolverExtensions
     {
-        public static IDependencyResolver UseRabbitMq(this IDependencyResolver resolver, string ampqConnectionString, string applicationName)
+		public static IDependencyResolver UseRabbitMq(this IDependencyResolver resolver, string ampqConnectionString, string exchangeName, string queueName = null)
         {
-            if (string.IsNullOrEmpty(applicationName))
+            if (string.IsNullOrEmpty(exchangeName))
             {
-                throw new ArgumentNullException("applicationName");
+                throw new ArgumentNullException("exchangeName");
             }
 
             if (string.IsNullOrEmpty(ampqConnectionString))
@@ -19,17 +19,18 @@ namespace SignalR.RabbitMQ
                 throw new ArgumentNullException("ampqConnectionString");
             }
 
-            var bus = new Lazy<RabbitMqMessageBus>(() => new RabbitMqMessageBus(resolver, ampqConnectionString, applicationName));
+            var bus = new Lazy<RabbitMqMessageBus>(() => new RabbitMqMessageBus(resolver, ampqConnectionString, exchangeName, queueName));
+
             resolver.Register(typeof(IMessageBus), () => bus.Value);
 
             return resolver;
         }
 
-        public static IDependencyResolver UseRabbitMq(this IDependencyResolver resolver, ConnectionFactory connectionfactory, string applicationName)
+		public static IDependencyResolver UseRabbitMq(this IDependencyResolver resolver, ConnectionFactory connectionfactory, string exchangeName, string queueName = null)
         {
-            if (string.IsNullOrEmpty(applicationName))
+            if (string.IsNullOrEmpty(exchangeName))
             {
-                throw new ArgumentNullException("applicationName");
+                throw new ArgumentNullException("exchangeName");
             }
 
             if (connectionfactory == null)
@@ -38,8 +39,8 @@ namespace SignalR.RabbitMQ
             }
 
             var ampqConnectionString = string.Format("host={0};virtualHost={1};username={2};password={3};requestedHeartbeat=10", connectionfactory.HostName, connectionfactory.VirtualHost, connectionfactory.UserName, connectionfactory.Password);
+            var bus = new Lazy<RabbitMqMessageBus>(() => new RabbitMqMessageBus(resolver, ampqConnectionString, exchangeName, queueName));
 
-            var bus = new Lazy<RabbitMqMessageBus>(() => new RabbitMqMessageBus(resolver, ampqConnectionString, applicationName));
             resolver.Register(typeof(IMessageBus), () => bus.Value);
 
             return resolver;

--- a/SignalR.RabbitMQ/RabbitMqMessageBus.cs
+++ b/SignalR.RabbitMQ/RabbitMqMessageBus.cs
@@ -13,7 +13,7 @@ namespace SignalR.RabbitMQ
         private RabbitConnection _rabbitConnection;
         private int _resource = 0;
 
-        public RabbitMqMessageBus(IDependencyResolver resolver, string ampqConnectionString, string applicationName)
+        public RabbitMqMessageBus(IDependencyResolver resolver, string ampqConnectionString, string applicationName, string queueName)
             : base(resolver)
         {
             if (string.IsNullOrEmpty(applicationName))
@@ -26,7 +26,7 @@ namespace SignalR.RabbitMQ
                 throw new ArgumentNullException("ampqConnectionString");
             }
 
-            ConnectToRabbit(ampqConnectionString, applicationName);
+            ConnectToRabbit(ampqConnectionString, applicationName, queueName);
         }
 
 		protected override void Dispose(bool disposing)
@@ -39,14 +39,14 @@ namespace SignalR.RabbitMQ
 			base.Dispose(disposing);
 		}
 
-        private void ConnectToRabbit(string ampqConnectionString, string applicationName)
+        private void ConnectToRabbit(string ampqConnectionString, string applicationName, string queueName)
         {
             if (1 == Interlocked.Exchange(ref _resource, 1))
             {
                 return;
             }
 
-            _rabbitConnection = new RabbitConnection(ampqConnectionString, applicationName);
+            _rabbitConnection = new RabbitConnection(ampqConnectionString, applicationName, queueName);
             _rabbitConnection.OnMessage( 
                 wrapper =>
                     {


### PR DESCRIPTION
For my uses it's necessary to name the exchange and queues to follow an internal naming standard, so I changed the `applicationName` parameter to be the exact exchange name instead and added an optional `queueName` parameter.

I also switched the exchange type to [fanout](http://www.rabbitmq.com/tutorials/tutorial-three-python.html), which ignores routing keys and delivers messages to all bound queues, which I think is what is intended here.
