### PR TITLE
Complete the Task returned from Send once the message has been queued

### DIFF
--- a/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
+++ b/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
@@ -37,9 +37,8 @@
     <Reference Include="EasyNetQ, Version=0.9.2.68, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EasyNetQ.0.9.2.68\lib\net40\EasyNetQ.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.1.1.1\lib\net40\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.Core">
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.1.1.3\lib\net40\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/SignalR.RabbitMQ.Example/Chat.cs
+++ b/SignalR.RabbitMQ.Example/Chat.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNet.SignalR;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
 
 namespace SignalR.RabbitMq.Example
 {
@@ -11,5 +13,18 @@ namespace SignalR.RabbitMq.Example
             Clients.Others.addMessage(string.Format("Some one said - {0} - {1}", message, _id), Context.ConnectionId);
             _id++;
         }
+
+        private const string GroupName = "SecretGroup";
+        public void SendGroup(string message)
+        {
+            Clients.Group(GroupName).addMessage(string.Format("{0} - {1}", message, _id), GroupName);
+        }
+
+        public Task JoinGroup(string groupName)
+        {
+            return Groups.Add(Context.ConnectionId, GroupName);
+        }
+
+
     }
 }

--- a/SignalR.RabbitMQ.Example/Global.asax.cs
+++ b/SignalR.RabbitMQ.Example/Global.asax.cs
@@ -29,7 +29,8 @@ namespace SignalR.RabbitMQ.Example
             {
                 UserName = "guest",
                 Password = "guest",
-                HostName = "192.168.60.2"
+                HostName = "localhost",
+                VirtualHost = "vhost"
             };
 
             var exchangeName = "SignalR.RabbitMQ-Example";

--- a/SignalR.RabbitMQ.Example/Views/Home/Index.cshtml
+++ b/SignalR.RabbitMQ.Example/Views/Home/Index.cshtml
@@ -7,6 +7,8 @@
   
   <input type="text" id="msg" />
   <a id="broadcast" href="#">Send message</a>
+  <a id="joingroup" href="#">Join group</a>
+  <a id="sendgroup" href="#">Send group message</a>
 
 <p>Messages : </p>
 <div id="console">  </div>
@@ -40,11 +42,35 @@
              });
         });
 
+        $("#sendgroup").click(function () {
+            // Call the chat method on the server
+            chat.server.sendGroup($('#msg').val())
+             .done(function () {
+                 console.log('Success!');
+             })
+             .fail(function (e) {
+                 console.warn(e);
+             });
+        });
+
+        $("#joingroup").click(function() {
+            chat.server.joinGroup("SecretGroup")
+             .done(function () {
+                 console.log('JoinGroup Success!');
+                 $("#joingroup").hide();
+             })
+             .fail(function (e) {
+                 console.warn(e);
+             });
+        });
+        
         $("#broadcast").hide();
+        $("#joingroup").hide();
 
         // Start the connection
         $.connection.hub.start(function () {
             $("#broadcast").show();
+            $("#joingroup").show();
             console.log("Success");
         });
     });

--- a/SignalR.RabbitMQ/RabbitMqMessageWrapper.cs
+++ b/SignalR.RabbitMQ/RabbitMqMessageWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNet.SignalR.Messaging;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace SignalR.RabbitMQ
 {
@@ -28,6 +29,9 @@ namespace SignalR.RabbitMQ
 
         [JsonIgnore]
         public ulong Id { get; set; }
+
+        [JsonIgnore]
+        public TaskCompletionSource<object> Tcs { get; set; }
 
         public byte[] Bytes { get; set; }
 


### PR DESCRIPTION
Added the TaskCompletionSource to the RabbitMqMessageWrapper so that it can be completed once the message is queued. This is required for the Task returned from Groups.Add(...) to complete and to rigger the ".done(..)" or ".fail(...)" on the client.
