### PR TITLE
Update EasyNetQ and RabbitMQ.Client to latest versions.

### DIFF
--- a/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
+++ b/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
@@ -37,9 +37,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EasyNetQ, Version=0.43.0.358, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="EasyNetQ, Version=0.50.7.399, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EasyNetQ.0.43.0.358\lib\net40\EasyNetQ.dll</HintPath>
+      <HintPath>..\packages\EasyNetQ.0.50.7.399\lib\net40\EasyNetQ.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,9 +48,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.4.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.5.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.4.3\lib\net35\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.5.4\lib\net40\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SignalR.RabbitMQ.Console/packages.config
+++ b/SignalR.RabbitMQ.Console/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EasyNetQ" version="0.43.0.358" targetFramework="net40" />
+  <package id="EasyNetQ" version="0.50.7.399" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.4.3" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.5.4" targetFramework="net45" />
 </packages>

--- a/SignalR.RabbitMQ.Example/SignalR.RabbitMQ.Example.csproj
+++ b/SignalR.RabbitMQ.Example/SignalR.RabbitMQ.Example.csproj
@@ -44,9 +44,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EasyNetQ, Version=0.43.0.358, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="EasyNetQ, Version=0.50.7.399, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EasyNetQ.0.43.0.358\lib\net40\EasyNetQ.dll</HintPath>
+      <HintPath>..\packages\EasyNetQ.0.50.7.399\lib\net40\EasyNetQ.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -74,9 +74,9 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.4.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.5.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.4.3\lib\net35\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.5.4\lib\net40\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SignalR.RabbitMQ.Example/Web.config
+++ b/SignalR.RabbitMQ.Example/Web.config
@@ -104,6 +104,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.4.0" newVersion="3.5.4.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/SignalR.RabbitMQ.Example/packages.config
+++ b/SignalR.RabbitMQ.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EasyNetQ" version="0.43.0.358" targetFramework="net40" />
+  <package id="EasyNetQ" version="0.50.7.399" targetFramework="net45" />
   <package id="EntityFramework" version="5.0.0" targetFramework="net40" />
   <package id="jQuery" version="1.7.1.1" targetFramework="net40" />
   <package id="jQuery.UI.Combined" version="1.8.20.1" targetFramework="net40" />
@@ -31,6 +31,6 @@
   <package id="Modernizr" version="2.5.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="Owin" version="1.0" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.4.3" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.5.4" targetFramework="net45" />
   <package id="WebGrease" version="1.1.0" targetFramework="net40" />
 </packages>

--- a/SignalR.RabbitMQ/RabbitConnectionBase.cs
+++ b/SignalR.RabbitMQ/RabbitConnectionBase.cs
@@ -34,7 +34,7 @@ namespace SignalR.RabbitMQ
             throw new NotImplementedException("Implement the StartListening method in your Rabbit connection class.");
         }
 
-        protected void OnReconnection()
+        protected void OnReconnection(object sender, EventArgs e)
         {
             if (OnReconnectionAction != null)
             {
@@ -42,7 +42,7 @@ namespace SignalR.RabbitMQ
             }
         }
 
-        protected void OnDisconnection()
+        protected void OnDisconnection(object sender, EventArgs e)
         {
             if (OnDisconnectionAction != null)
             {

--- a/SignalR.RabbitMQ/SignalR.RabbitMQ.csproj
+++ b/SignalR.RabbitMQ/SignalR.RabbitMQ.csproj
@@ -36,17 +36,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EasyNetQ, Version=0.43.0.358, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="EasyNetQ, Version=0.50.7.399, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EasyNetQ.0.43.0.358\lib\net40\EasyNetQ.dll</HintPath>
+      <HintPath>..\packages\EasyNetQ.0.50.7.399\lib\net40\EasyNetQ.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.2.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.4.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.5.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.4.3\lib\net35\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.5.4\lib\net40\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -68,6 +68,7 @@
     <Compile Include="RabbitMqScaleoutConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/SignalR.RabbitMQ/app.config
+++ b/SignalR.RabbitMQ/app.config
@@ -3,16 +3,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.5.4.0" newVersion="3.5.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-  </startup>
 </configuration>

--- a/SignalR.RabbitMQ/packages.config
+++ b/SignalR.RabbitMQ/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EasyNetQ" version="0.43.0.358" targetFramework="net40" />
+  <package id="EasyNetQ" version="0.50.7.399" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.4.3" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.5.4" targetFramework="net45" />
 </packages>

--- a/SignalR.RabbitMq.nuspec
+++ b/SignalR.RabbitMq.nuspec
@@ -13,8 +13,8 @@
     <copyright>Copyright 2015</copyright>
     <tags>SignalR RabbitMQ</tags>
     <dependencies>
-	   <dependency id="EasyNetQ" version="0.43.0.358" />
-      <dependency id="RabbitMQ.Client" version="3.4.3" />
+	   <dependency id="EasyNetQ" version="0.50.7.399" />
+      <dependency id="RabbitMQ.Client" version="3.5.4" />
       <dependency id="Microsoft.AspNet.SignalR.Core" version="2.2.0" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Hi,

This PR contains updated references to the `EasyNetQ` and `RabbitMQ.Client` packages.  v3.5 of `RabbitMQ.Client` had a breaking change which was fixed in v0.5 of `EasyNetQ`.  The only code change required was in `RabbitConnectionBase` - the event handler signatures were changed.