### PR TITLE
Ack messages

### DIFF
--- a/SignalR.RabbitMQ/RabbitConnection.cs
+++ b/SignalR.RabbitMQ/RabbitConnection.cs
@@ -45,11 +45,18 @@ namespace SignalR.RabbitMQ
             var consumer = new EventingBasicConsumer(_subscribeModel);
             consumer.Received += (sender, args) =>
             {
-                OnMessage(new RabbitMqMessageWrapper
+                try
                 {
-                    Bytes = args.Body,
-                    Id = Convert.ToUInt64(args.BasicProperties.Headers["stamp"])
-                });
+                    OnMessage(new RabbitMqMessageWrapper
+                    {
+                        Bytes = args.Body,
+                        Id = Convert.ToUInt64(args.BasicProperties.Headers["stamp"])
+                    });
+                }
+                finally
+                {
+                    _subscribeModel.BasicAck(args.DeliveryTag, multiple: false);
+                }
             };
 
             _subscribeModel.BasicConsume(Configuration.QueueName, noAck: false, consumer: consumer);


### PR DESCRIPTION
So sorry about this!  This commit was actually in our history, but somehow I lost it in the squash when I was fixing line endings and tabs/spaces.  This fixes unacked messages building up in Rabbit while the connection is open.