### PR TITLE
Upgrading RabbitMQ library and changing .NET framework target to 4.5.2

### DIFF
--- a/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
+++ b/SignalR.RabbitMQ.Console/SignalR.RabbitMQ.Console.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SignalR.RabbitMQ.Console</RootNamespace>
     <AssemblyName>SignalR.RabbitMQ.Console</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -44,8 +44,8 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\packages\RabbitMQ.Client.3.6.3\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SignalR.RabbitMQ.Console/app.config
+++ b/SignalR.RabbitMQ.Console/app.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.5.0" newVersion="3.5.5.0" />
+        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.5.0" newVersion="3.5.5.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
 </configuration>

--- a/SignalR.RabbitMQ.Console/packages.config
+++ b/SignalR.RabbitMQ.Console/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.6.3" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
 </packages>

--- a/SignalR.RabbitMQ.Example/SignalR.RabbitMQ.Example.csproj
+++ b/SignalR.RabbitMQ.Example/SignalR.RabbitMQ.Example.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SignalR.RabbitMQ.Example</RootNamespace>
     <AssemblyName>SignalR.RabbitMQ.Example</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -71,8 +71,8 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\packages\RabbitMQ.Client.3.6.3\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -84,9 +84,9 @@
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/SignalR.RabbitMQ.Example/Web.config
+++ b/SignalR.RabbitMQ.Example/Web.config
@@ -27,7 +27,7 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5.2" />
     <authentication mode="Forms">
       <forms loginUrl="~/Account/Login" timeout="2880" />
     </authentication>

--- a/SignalR.RabbitMQ.Example/packages.config
+++ b/SignalR.RabbitMQ.Example/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="5.0.0" targetFramework="net40" />
+  <package id="EntityFramework" version="5.0.0" targetFramework="net40" requireReinstallation="true" />
   <package id="jQuery" version="1.7.1.1" targetFramework="net40" />
   <package id="jQuery.UI.Combined" version="1.8.20.1" targetFramework="net40" />
   <package id="jQuery.Validation" version="1.9.0.1" targetFramework="net40" />
@@ -22,14 +22,14 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.jQuery.Unobtrusive.Ajax" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" requireReinstallation="true" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Modernizr" version="2.5.3" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" requireReinstallation="true" />
   <package id="Owin" version="1.0" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.6.3" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
   <package id="WebGrease" version="1.1.0" targetFramework="net40" />
 </packages>

--- a/SignalR.RabbitMQ/SignalR.RabbitMQ.csproj
+++ b/SignalR.RabbitMQ/SignalR.RabbitMQ.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SignalR.RabbitMQ</RootNamespace>
     <AssemblyName>SignalR.RabbitMQ</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -40,8 +40,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.2.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\packages\RabbitMQ.Client.3.6.3\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.4.1.0\lib\net451\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SignalR.RabbitMQ/app.config
+++ b/SignalR.RabbitMQ/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.5.0" newVersion="3.5.5.0" />
+        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.5.0" newVersion="3.5.5.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/SignalR.RabbitMQ/packages.config
+++ b/SignalR.RabbitMQ/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.6.3" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
 </packages>

--- a/SignalR.RabbitMq.nuspec
+++ b/SignalR.RabbitMq.nuspec
@@ -2,25 +2,25 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>SignalR.RabbitMq</id>
-    <version>2.2.7</version>
+    <version>2.2.8</version>
     <authors>Mark deVilliers</authors>
     <owners>Mark deVilliers</owners>
     <licenseUrl>https://raw.github.com/mdevilliers/SignalR.RabbitMq/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mdevilliers/SignalR.RabbitMq</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Implementation of a SignalR backplane with RabbitMq as the backing store.</description>
-    <releaseNotes>Fix to ensure messages are acked.</releaseNotes>
+    <releaseNotes>Upgrade of RabbitMQ library.</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>SignalR RabbitMQ</tags>
     <dependencies>
-      <dependency id="RabbitMQ.Client" version="3.6.3" />
+      <dependency id="RabbitMQ.Client" version="4.1.0" />
       <dependency id="Microsoft.AspNet.SignalR.Core" version="2.2.0" />
     </dependencies>
   </metadata>
    <files>
 		<file src="rabbitmq-plugin\**\*.*" target="rabbitmq-plugin" />
 		<file src="build\readme.txt" target="readme.txt" />
-		<file src="SignalR.RabbitMQ\bin\*\SignalR.RabbitMQ.*" target="lib\net45" />
+		<file src="SignalR.RabbitMQ\bin\*\SignalR.RabbitMQ.*" target="lib\net452" />
 		<file src="SignalR.RabbitMQ\*.cs" target="src" />
 	</files>
 </package>


### PR DESCRIPTION
Upgrading RabbitMQ dependency. Not sure how you want to handle this as the new library required a higher .NET target. I moved it to .NET 4.5.2.